### PR TITLE
Refactor/이미지 및 무한스크롤 관련 개선 작업

### DIFF
--- a/src/app/movie/components/movie-item.tsx
+++ b/src/app/movie/components/movie-item.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
+import { LazyImage } from '@/components/lazy-image';
 
 const MovieItem = ({ imageUrl }: { imageUrl: string }) => {
   return (
     <div className="w-full h-full aspect-video rounded-lg overflow-hidden cursor-pointer transition duration-300 ease-in-out hover:brightness-75">
-      <img
+      <LazyImage
         className="w-full h-full"
         alt={'movie'}
         src={`https://image.tmdb.org/t/p/w300/${imageUrl}`}

--- a/src/app/movie/components/movie-item.tsx
+++ b/src/app/movie/components/movie-item.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 
 const MovieItem = ({ imageUrl }: { imageUrl: string }) => {
   return (
-    <div className="rounded-lg overflow-hidden cursor-pointer transition duration-300 ease-in-out hover:brightness-75">
+    <div className="w-full h-full aspect-video rounded-lg overflow-hidden cursor-pointer transition duration-300 ease-in-out hover:brightness-75">
       <img
-        className="w-full"
+        className="w-full h-full"
         alt={'movie'}
         src={`https://image.tmdb.org/t/p/w300/${imageUrl}`}
         srcSet={`https://image.tmdb.org/t/p/w300/${imageUrl} 300w, https://image.tmdb.org/t/p/w780/${imageUrl} 780w, https://image.tmdb.org/t/p/w1280/${imageUrl} 1280w`}

--- a/src/app/movie/components/now-playing-movie-list.tsx
+++ b/src/app/movie/components/now-playing-movie-list.tsx
@@ -9,12 +9,6 @@ const NowPlayingMovieList = () => {
 
   const observerRef = useRef<HTMLDivElement>(null);
 
-  /**
-   * TODO: 무한스크롤 이슈
-   *  - 이미지가 로드가 늦게 되기때문에 처음에
-   *    인터섹션 옵저버 요소가 먼저 보여지므로
-   *    항상 처음 한번은 다음 페이지를 호출하는 문제 발생
-   * */
   useEffect(() => {
     const observer = new IntersectionObserver(
       (entries) => {

--- a/src/app/movie/components/now-playing-movie-list.tsx
+++ b/src/app/movie/components/now-playing-movie-list.tsx
@@ -1,28 +1,16 @@
-import React, { useEffect, useRef } from 'react';
+import React from 'react';
 import { useGetNowPlayingMovieList } from '@/app/movie/hooks/use-get-now-playing-movie-list';
 import { MovieItem } from '@/app/movie/components/movie-item';
+import { useInView } from '@/hooks/use-in-view';
 
 const NowPlayingMovieList = () => {
   const { data, error, isFetching, fetchNextPage } = useGetNowPlayingMovieList({
     page: 1,
   });
 
-  const observerRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries[0].isIntersecting) {
-          fetchNextPage();
-        }
-      },
-      { threshold: 1.0 },
-    );
-
-    if (observerRef.current) observer.observe(observerRef.current);
-
-    return () => observer.disconnect();
-  }, []);
+  const { ref } = useInView<HTMLDivElement>(() => {
+    fetchNextPage();
+  }, {});
 
   if (error && !isFetching) {
     throw error;
@@ -33,7 +21,7 @@ const NowPlayingMovieList = () => {
       {data.pages.map((item) => {
         return <MovieItem key={item.id} imageUrl={item.backdrop_path} />;
       })}
-      <div ref={observerRef} className="w-0 h-0" />
+      <div ref={ref} className="w-0 h-0" />
     </>
   );
 };

--- a/src/app/movie/page.tsx
+++ b/src/app/movie/page.tsx
@@ -5,7 +5,7 @@ import { ErrorBoundary } from '@/components/error-boundary';
 const MoviePage = () => {
   return (
     <div className="flex flex-col px-10 py-6">
-      <div className="w-full grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-y-4 gap-x-1">
+      <div className="w-full h-full grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-y-4 gap-x-1">
         {/* TODO: 에러, 로딩 컴포넌트 임시 사용 */}
         <ErrorBoundary fallback={<div>에러</div>}>
           <Suspense fallback={<div>로딩중</div>}>

--- a/src/components/lazy-image.tsx
+++ b/src/components/lazy-image.tsx
@@ -1,0 +1,37 @@
+import React, { useRef } from 'react';
+import { useInView } from '@/hooks/use-in-view';
+
+type ImageProps = Omit<React.ImgHTMLAttributes<HTMLImageElement>, 'alt'> & {
+  alt: string;
+};
+
+const LazyImage = ({ alt, src, srcSet, ...props }: ImageProps) => {
+  const imageRef = useRef<HTMLImageElement>(null);
+
+  const handleIntersectImage = () => {
+    const $img = imageRef.current;
+
+    if (!$img) {
+      return;
+    }
+
+    if ($img.dataset.src) {
+      $img.src = $img.dataset.src;
+    }
+
+    if ($img.dataset.srcset) {
+      $img.srcset = $img.dataset.srcset;
+    }
+  };
+
+  const { ref } = useInView<HTMLImageElement>(handleIntersectImage, { triggerOnce: true });
+
+  const handleSetRef = ($img: HTMLImageElement | null) => {
+    ref.current = $img;
+    imageRef.current = $img;
+  };
+
+  return <img ref={handleSetRef} alt={alt} data-src={src} data-srcset={srcSet} {...props} />;
+};
+
+export { LazyImage };

--- a/src/components/lazy-image.tsx
+++ b/src/components/lazy-image.tsx
@@ -1,12 +1,14 @@
-import React, { useRef } from 'react';
+import React, { useRef, useState } from 'react';
 import { useInView } from '@/hooks/use-in-view';
 
 type ImageProps = Omit<React.ImgHTMLAttributes<HTMLImageElement>, 'alt'> & {
   alt: string;
 };
 
-const LazyImage = ({ alt, src, srcSet, ...props }: ImageProps) => {
+const LazyImage = ({ alt, src, srcSet, className, ...props }: ImageProps) => {
   const imageRef = useRef<HTMLImageElement>(null);
+  const [isImageLoad, setIsImageLoad] = useState<boolean>(false);
+  const [isError, setIsError] = useState<boolean>(false);
 
   const handleIntersectImage = () => {
     const $img = imageRef.current;
@@ -31,7 +33,29 @@ const LazyImage = ({ alt, src, srcSet, ...props }: ImageProps) => {
     imageRef.current = $img;
   };
 
-  return <img ref={handleSetRef} alt={alt} data-src={src} data-srcset={srcSet} {...props} />;
+  const handleImageLoad = () => {
+    setIsImageLoad(true);
+  };
+  const handleImageError = () => {
+    setIsError(true);
+  };
+
+  return (
+    <div className={`w-full h-full ${className}`}>
+      {!isImageLoad && !isError && <div className="w-full h-full bg-gray-300 animate-pulse" />}
+      {isError && <div className="w-full h-full bg-gray-300 flex items-center justify-center text-gray-500">Error</div>}
+      <img
+        ref={handleSetRef}
+        className={`w-full h-full transition-opacity duration-300 ${isImageLoad ? 'opacity-100' : 'opacity-0'}`}
+        onLoad={handleImageLoad}
+        onError={handleImageError}
+        alt={alt}
+        data-src={src}
+        data-srcset={srcSet}
+        {...props}
+      />
+    </div>
+  );
 };
 
 export { LazyImage };

--- a/src/hooks/use-in-view.ts
+++ b/src/hooks/use-in-view.ts
@@ -1,0 +1,52 @@
+import { useEffect, useRef } from 'react';
+
+interface UseInViewOptions extends IntersectionObserverInit {
+  triggerOnce?: boolean;
+}
+
+const useInView = <T extends HTMLElement>(
+  handleIntersect: () => void,
+  { root = null, rootMargin = '0px', threshold = 0, triggerOnce = false }: UseInViewOptions,
+) => {
+  const targetRef = useRef<T | null>(null);
+
+  useEffect(() => {
+    /**
+     * 타켓요소가 존재 x, IntersectionObserver 가 지원하지 않는 브라우저일경우
+     * TODO: IntersectionObserver 가 지원하지 않는 브라우저이면 대응 방안 적용
+     * */
+    if (!targetRef.current || typeof IntersectionObserver === 'undefined') {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries: IntersectionObserverEntry[]) => {
+        const $entry = entries[0];
+        const isIntersecting = $entry.isIntersecting;
+
+        if (isIntersecting) {
+          handleIntersect();
+
+          if (triggerOnce) {
+            observer.disconnect();
+          }
+        }
+      },
+      {
+        root,
+        rootMargin,
+        threshold,
+      },
+    );
+
+    observer.observe(targetRef.current);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+  return { ref: targetRef };
+};
+
+export { useInView };


### PR DESCRIPTION
## 🔎 작업 내용

- 영화 아이템 스타일 크기 비율 고정으로 변경
- IntersectionObserver 를 사용하기 위한 커스텀 훅 useInView 생성
- 이미지 지연 로드를 위한 LazyImage 컴포넌트 생성

## 🚨이슈 사항
- IntersectionObserver를 지원하지 않는 브라우저 대응 방법 필요. [커밋](https://github.com/f-lab-edu/umbra/commit/6d5688dbb9b5c4c7b3eb28b4c7e626c791366178)

## 🍉 작업 영상

https://github.com/user-attachments/assets/19b78baf-6a77-49ff-b9b2-4daee0ecd9d3



